### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Brown Math Camp 2023
 
 - [Lecture 1](out/lectures/Math%20Camp%202023%20Lecture%201%20-%20Proofs%2C%20Metric%20Spaces%2C%20Topology.pdf)
 - [Lecture 2](out/lectures/Math%20Camp%202023%20Lecture%202%20-%20Sequences%2C%20Continuity.pdf)
-- [Lecture 3](out/lectures/Math%20Camp%202023%20Lecture%203%20-%20Correspondences%2C%20Compactness%2C%20EVT.pdf)
+- [Lecture 3](out/lectures/Math%20Camp%202023%20Lecture%203%20-%20Compactness%2C%20EVT%2C%20Correspondences.pdf)
 - [Lecture 4](out/lectures/Math%20Camp%202023%20Lecture%204%20-%20Differentiation%2C%20IFT%2C%20Unconstrained%20Optimization.pdf)
 - [Lecture 5](out/lectures/Math%20Camp%202023%20Lecture%205%20-%20Constrained%20Optimization%2C%20Envelope%20Theorem%2C%20Integration.pdf)
 - [Lecture 6](out/lectures/Math%20Camp%202023%20Lecture%206%20-%20Linear%20Algebra%2C%20ODE.pdf)

--- a/src/homework/ps3.tex
+++ b/src/homework/ps3.tex
@@ -19,9 +19,9 @@
   \item {\itshape
     Take a collection of functions with $f_i: \Omega \to \mathbb{R}^N$, $\Omega \subseteq \mathbb{R}^M, i \in \mathbb{N}$. The collection $\set{f_i}$ defines a sequence of funtions, and for each $x \in \Omega$ we have a possibly different sequence $\set{f_i(x)}$ in $\mathbb{R}^N$.
 
-    Let $\set{f_i}$ be a sequence of functions, with $f_i: \Omega \to \mathbb{R}^N$ and $\Omega \subseteq \mathbb{R}^M$. We say that $\set{f_i}$ \textbf{point-wise convrges} to $f: \Omega_0 \to \mathbb{R}^N$ if $x \in \Omega_0 \implies f_i(x) \to f(x)$.
+    Let $\set{f_i}$ be a sequence of functions, with $f_i: \Omega \to \mathbb{R}^N$ and $\Omega \subseteq \mathbb{R}^M$. We say that $\set{f_i}$ \textbf{point-wise converges} to $f: \Omega_0 \to \mathbb{R}^N$ if $x \in \Omega_0 \implies f_i(x) \to f(x)$.
 
-    Let $\set{f_i}$ be a sequence of functions, with $f_i: \Omega \to \mathbb{R}^N$ and $\Omega \subseteq \mathbb{R}^M$. We say that $\set{f_i}$ \textbf{uniformly convrges} to $f: \Omega_0 \to \mathbb{R}^N$ if $\forall \varepsilon > 0 ~~ \exists I_0(\varepsilon)$ s.t. for $i > I_0(\varepsilon)$ we have $\Fnorm{f_i(x) - f(x)} < \varepsilon$.
+    Let $\set{f_i}$ be a sequence of functions, with $f_i: \Omega \to \mathbb{R}^N$ and $\Omega \subseteq \mathbb{R}^M$. We say that $\set{f_i}$ \textbf{uniformly converges} to $f: \Omega_0 \to \mathbb{R}^N$ if $\forall \varepsilon > 0 ~~ \exists I_0(\varepsilon)$ s.t. for $i > I_0(\varepsilon)$ we have $\Fnorm{f_i(x) - f(x)} < \varepsilon$.
 
     \begin{enumerate}[a)]
       \item \textit{Let $f_i(x) = x / i$ and $f(x) = 0$. Check that $f_i \to f$ point-wise.}

--- a/src/homework/solutions3.tex
+++ b/src/homework/solutions3.tex
@@ -19,9 +19,9 @@
   \item {\itshape
     Take a collection of functions with $f_i: \Omega \to \mathbb{R}^N$, $\Omega \subseteq \mathbb{R}^M, i \in \mathbb{N}$. The collection $\set{f_i}$ defines a sequence of funtions, and for each $x \in \Omega$ we have a possibly different sequence $\set{f_i(x)}$ in $\mathbb{R}^N$.
 
-    Let $\set{f_i}$ be a sequence of functions, with $f_i: \Omega \to \mathbb{R}^N$ and $\Omega \subseteq \mathbb{R}^M$. We say that $\set{f_i}$ \textbf{point-wise convrges} to $f: \Omega_0 \to \mathbb{R}^N$ if $x \in \Omega_0 \implies f_i(x) \to f(x)$.
+    Let $\set{f_i}$ be a sequence of functions, with $f_i: \Omega \to \mathbb{R}^N$ and $\Omega \subseteq \mathbb{R}^M$. We say that $\set{f_i}$ \textbf{point-wise converges} to $f: \Omega_0 \to \mathbb{R}^N$ if $x \in \Omega_0 \implies f_i(x) \to f(x)$.
 
-    Let $\set{f_i}$ be a sequence of functions, with $f_i: \Omega \to \mathbb{R}^N$ and $\Omega \subseteq \mathbb{R}^M$. We say that $\set{f_i}$ \textbf{uniformly convrges} to $f: \Omega_0 \to \mathbb{R}^N$ if $\forall \varepsilon > 0 ~~ \exists I_0(\varepsilon)$ s.t. for $i > I_0(\varepsilon)$ we have $\Fnorm{f_i(x) - f(x)} < \varepsilon$. }
+    Let $\set{f_i}$ be a sequence of functions, with $f_i: \Omega \to \mathbb{R}^N$ and $\Omega \subseteq \mathbb{R}^M$. We say that $\set{f_i}$ \textbf{uniformly converges} to $f: \Omega_0 \to \mathbb{R}^N$ if $\forall \varepsilon > 0 ~~ \exists I_0(\varepsilon)$ s.t. for $i > I_0(\varepsilon)$ we have $\Fnorm{f_i(x) - f(x)} < \varepsilon$. }
 
     \begin{enumerate}[a)]
       \item \textit{Let $f_i(x) = x / i$ and $f(x) = 0$. Check that $f_i \to f$ point-wise.}


### PR DESCRIPTION
This pull request fixes
- a broken url for "Lecture 3" in the README and
- some spelling typos in the plaintext.

Thank you for the notes!